### PR TITLE
fix: fix docker env, update cargo-chef

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,7 @@ dependencies = [
  "ignore",
  "lazy_static",
  "lettre",
+ "openssl",
  "regex",
  "serde",
  "tera",
@@ -1347,6 +1348,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.4.2+3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1364,7 @@ checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ serde = { version = "1.0.210", features = ["derive"] }
 chrono = { version = "0.4.39", features = ["serde"] }
 lettre = "0.11"
 dotenv = "0.15.0"
+openssl = { version = "0.10.71", features = ["vendored"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:0.1.68-rust-latest AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
 WORKDIR /cmgoold
 
 FROM chef AS planner

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,5 +1,7 @@
 services:
   web:
+    volumes:
+      - ./.env:/cmgoold/.env
     build: .
     ports:
       - "8080:8080"

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -13,6 +13,7 @@ services:
       - /etc/letsencrypt/live/cmgoold.com/privkey.pem:/etc/letsencrypt/live/cmgoold.com/privkey.pem
       - /etc/nginx/logs/error.log:/etc/nginx/logs/error.log
       - /etc/nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ../.env:/cmgoold/.env
 
   site:
     container_name: cmgoold.com


### PR DESCRIPTION
Adds `openssl` as a dependency, copies environment variable file